### PR TITLE
Make constants final in  DepQBF4J

### DIFF
--- a/DepQBF4J-0.1/src/depqbf4j/DepQBF4J.java
+++ b/DepQBF4J-0.1/src/depqbf4j/DepQBF4J.java
@@ -23,17 +23,17 @@
 package depqbf4j;
 
 public class DepQBF4J {
-	public static byte QTYPE_EXISTS = -1;
-	public static byte QTYPE_UNDEF = 0;
-	public static byte QTYPE_FORALL = 1;
+	public static final byte QTYPE_EXISTS = -1;
+	public static final byte QTYPE_UNDEF = 0;
+	public static final byte QTYPE_FORALL = 1;
 
-	public static byte RESULT_UNKNOWN = 0;
-	public static byte RESULT_SAT = 10;
-	public static byte RESULT_UNSAT = 20;
+	public static final byte RESULT_UNKNOWN = 0;
+	public static final byte RESULT_SAT = 10;
+	public static final byte RESULT_UNSAT = 20;
 
-	public static byte ASSIGNMENT_FALSE = -1;
-	public static byte ASSIGNMENT_UNDEF = 0;
-	public static byte ASSIGNMENT_TRUE = 1;
+	public static final byte ASSIGNMENT_FALSE = -1;
+	public static final byte ASSIGNMENT_UNDEF = 0;
+	public static final byte ASSIGNMENT_TRUE = 1;
 
 	static {
 		System.loadLibrary("depqbf4j");


### PR DESCRIPTION
Firstly, I am finding the solver very handy and fast for my applications especially the JNI interface is very useful, so thanks for that!

While using the java interface through JNI I found the constants declared in DepQBF4J.java were not final.
The problem with this is a switch statement requires a constant expression. At the moment one cannot do something like:

``` java
 public boolean isSatisfiable()  {
        byte exitCode  = DepQBF4J.sat();
        switch (exitCode){
            case DepQBF4J.RESULT_SAT:
                return true;
            case DepQBF4J.RESULT_UNSAT:
                return false;
            default:
            .....
}
```

The changes just add a final modifier to the constants so they can be used as such.
