### PR TITLE
using -install_name instead of -soname on OS X

### DIFF
--- a/README
+++ b/README
@@ -147,11 +147,6 @@ will run *substantially* slower in this case. As usual, using the compiler
 flag 'DNDEBUG' removes all assertions from the code, regardless from the value
 of 'FULL_ASSERT'.
 
-Compilation on a Mac:
-
-Depending on your system, it might be necessary to replace "-soname"
-by "-install_name" in the makefile.
-
 
 -----------------------
 CONFIGURATION AND USAGE

--- a/makefile
+++ b/makefile
@@ -8,6 +8,15 @@ MAJOR=1
 MINOR=0
 VERSION=$(MAJOR).$(MINOR)
 
+UNAME:=$(shell uname)
+
+ifeq ($(UNAME), Darwin)
+# Mac OS X
+SONAME=-install_name
+else
+SONAME=-soname
+endif
+
 .SUFFIXES: .c .o .fpico
 
 .c.fpico:
@@ -54,7 +63,7 @@ libqdpll.a: qdpll.o qdpll_pqueue.o qdpll_mem.o qdpll_dep_man_qdag.o
 	ranlib $@
 
 libqdpll.so.$(VERSION): qdpll.fpico qdpll_pqueue.fpico qdpll_mem.fpico qdpll_dep_man_qdag.fpico
-	$(CC) -shared -Wl,-soname,libqdpll.so.$(MAJOR) $^ -o $@
+	$(CC) -shared -Wl,$(SONAME),libqdpll.so.$(MAJOR) $^ -o $@
 
 clean:
 	rm -f *.so.$(VERSION) *.fpico *.a *.o *.gcno *.gcda *.gcov *~ gmon.out depqbf

--- a/makefile
+++ b/makefile
@@ -8,13 +8,17 @@ MAJOR=1
 MINOR=0
 VERSION=$(MAJOR).$(MINOR)
 
+TARGETS:=qdpll_main.o qdpll_app.o libqdpll.a
+
 UNAME:=$(shell uname)
 
 ifeq ($(UNAME), Darwin)
 # Mac OS X
 SONAME=-install_name
+TARGETS+=libqdpll.$(VERSION).dylib
 else
 SONAME=-soname
+TARGETS+=libqdpll.so.$(VERSION)
 endif
 
 .SUFFIXES: .c .o .fpico
@@ -25,7 +29,7 @@ endif
 .c.o:
 	$(CC) $(CFLAGS) -c $< -o $@
 
-depqbf: qdpll_main.o qdpll_app.o libqdpll.a libqdpll.so.$(VERSION)
+depqbf: $(TARGETS)
 	$(CC) $(CFLAGS) qdpll_main.o qdpll_app.o -L. -lqdpll -o depqbf
 
 qdpll_main.o: qdpll_main.c qdpll.h
@@ -65,5 +69,8 @@ libqdpll.a: qdpll.o qdpll_pqueue.o qdpll_mem.o qdpll_dep_man_qdag.o
 libqdpll.so.$(VERSION): qdpll.fpico qdpll_pqueue.fpico qdpll_mem.fpico qdpll_dep_man_qdag.fpico
 	$(CC) -shared -Wl,$(SONAME),libqdpll.so.$(MAJOR) $^ -o $@
 
+libqdpll.$(VERSION).dylib: libqdpll.so.$(VERSION)
+	cp $< $@
+
 clean:
-	rm -f *.so.$(VERSION) *.fpico *.a *.o *.gcno *.gcda *.gcov *~ gmon.out depqbf
+	rm -f *.so.$(VERSION) *.dylib *.fpico *.a *.o *.gcno *.gcda *.gcov *~ gmon.out depqbf


### PR DESCRIPTION
This fixes the compilation on OS X without requiring users to manually edit the `makefile`.