### PR TITLE
fix warnings with wrong formats in fprintf

### DIFF
--- a/qdpll.c
+++ b/qdpll.c
@@ -6805,7 +6805,7 @@ cover_by_assignment_collect_univ_vars (QDPLL *qdpll,
           assert (c->qbcp_qbce_blocked);
           if (qdpll->options.verbosity >= 2)
             {
-              fprintf (stderr, "seen blocked clause at level %d:\n", 
+              fprintf (stderr, "seen blocked clause at level %ld:\n",
                        sp - qdpll->qbcp_qbce_blocked_clauses.start);
               print_constraint (qdpll, c);
             }
@@ -11411,7 +11411,7 @@ qbcp_qbce_delete_list_entry (QDPLL *qdpll, QBCENonBlockedWitnessStack *list,
   QBCENonBlockedWitness last = QDPLL_POP_STACK (*list);
   if (qdpll->options.verbosity >= 3)
     {
-      fprintf (stderr, "WATCHING: deleting list entry, new list size %u\n", QDPLL_COUNT_STACK (*list));
+      fprintf (stderr, "WATCHING: deleting list entry, new list size %lu\n", QDPLL_COUNT_STACK (*list));
       fprintf (stderr, "WATCHING: deleting %s entry -- last item:\n", is_witness_entry ? "witness" : "maybe-blocked-clause");
       fprintf (stderr, "WATCHING:   clause: ");
       print_constraint (qdpll, last.blit_occ.constraint);
@@ -12604,7 +12604,7 @@ qbcp_qbce_find_blocked_clauses (QDPLL *qdpll)
                               qdpll->stats.qbcp_qbce_ignored_maybe_blocking_literals_by_occ_limit++;
 #endif
                               if (qdpll->options.verbosity >= 3)
-                                fprintf (stderr, "QBCE: skipping maybe blocking literal %d -- %soccs-cnt %u > limit %u\n", 
+                                fprintf (stderr, "QBCE: skipping maybe blocking literal %d -- %soccs-cnt %lu > limit %u\n",
                                          lit, QDPLL_LIT_NEG (lit) ? "pos-" : "neg-", 
                                          QDPLL_COUNT_STACK (*occs), qdpll->options.qbcp_qbce_find_witness_max_occs);
                               continue;


### PR DESCRIPTION
On my system (Ubuntu 22.04, gcc 11.3.0, amd64) it generates the warnings below when compiling. This commit fixes the warnings by applying the changes suggested by the compiler. 
```
cc -Wextra -Wall -Wno-unused-parameter -Wno-unused -pedantic -std=c99 -DNDEBUG -O3  -fPIC -c qdpll.c -o qdpll.fpico
qdpll.c: In function ‘cover_by_assignment_collect_univ_vars’:
qdpll.c:6808:63: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘long int’ [-Wformat=]
 6808 |               fprintf (stderr, "seen blocked clause at level %d:\n",
      |                                                              ~^
      |                                                               |
      |                                                               int
      |                                                              %ld
 6809 |                        sp - qdpll->qbcp_qbce_blocked_clauses.start);
      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                           |
      |                           long int
qdpll.c: In function ‘qbcp_qbce_delete_list_entry’:
qdpll.c:11414:71: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 3 has type ‘long unsigned int’ [-Wformat=]
11414 |       fprintf (stderr, "WATCHING: deleting list entry, new list size %u\n", QDPLL_COUNT_STACK (*list));
      |                                                                      ~^
      |                                                                       |
      |                                                                       unsigned int
      |                                                                      %lu
qdpll.c: In function ‘qbcp_qbce_find_blocked_clauses’:
qdpll.c:12607:107: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 5 has type ‘long unsigned int’ [-Wformat=]
12607 |                                 fprintf (stderr, "QBCE: skipping maybe blocking literal %d -- %soccs-cnt %u > limit %u\n",
      |                                                                                                          ~^
      |                                                                                                           |
      |                                                                                                           unsigned int
      |                                                                                                          %lu
```